### PR TITLE
Update MailchimpCampaign.php

### DIFF
--- a/Model/MailchimpCampaign.php
+++ b/Model/MailchimpCampaign.php
@@ -245,6 +245,7 @@ class MailchimpCampaign extends MailchimpAppModel {
 		$options = array(
 			'options' => $campaignOptions
 		);
+		$options['type'] = $type;
 		$options['content'] = $content;
 		$options['segment_opts'] = $segmentOpts;
 		$options['type_opts'] = $typeOpts;


### PR DESCRIPTION
Setting campaign type in the campaignCreate function. Otherwise `$type` is never used and Mailchimp complains it can't find it.