### PR TITLE
return response on success

### DIFF
--- a/Model/MailchimpAppModel.php
+++ b/Model/MailchimpAppModel.php
@@ -43,7 +43,7 @@ class MailchimpAppModel extends AppModel {
 			$args[Inflector::underscore($key)] = $value;
 		}
 		$this->response = $this->Mailchimp->call($method, $args);
-		if (!isset($this->response['status'])) {
+		if (!isset($this->response['status']) || $this->response['status'] != 'error') {
 			return $this->response;
 		}
 		if ($this->settings['exceptions']) {

--- a/Model/MailchimpAppModel.php
+++ b/Model/MailchimpAppModel.php
@@ -43,7 +43,7 @@ class MailchimpAppModel extends AppModel {
 			$args[Inflector::underscore($key)] = $value;
 		}
 		$this->response = $this->Mailchimp->call($method, $args);
-		if (!isset($this->response['status']) || $this->response['status'] != 'error') {
+		if (!isset($this->response['status']) || $this->response['status'] !== 'error') {
 			return $this->response;
 		}
 		if ($this->settings['exceptions']) {


### PR DESCRIPTION
As far as I can tell, not all `responses` are properly documented on success in the Mailchimp API docs ([example](https://apidocs.mailchimp.com/api/2.0/campaigns/create.php)). However, all `errors` should contain `{"status": "error", ... }`.

Would this patch be more appropriate?